### PR TITLE
replace using namespace `Zend\Diactoros` to `Laminas\Diactoros`

### DIFF
--- a/src/Providers/SteamAuth.php
+++ b/src/Providers/SteamAuth.php
@@ -16,8 +16,8 @@ use Illuminate\Support\Fluent;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use GuzzleHttp\Client as GuzzleClient;
-use Zend\Diactoros\Response\RedirectResponse;
-use Zend\Diactoros\Uri;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Uri;
 
 /**
  * Class SteamAuth

--- a/src/Providers/SteamAuthInterface.php
+++ b/src/Providers/SteamAuthInterface.php
@@ -13,7 +13,7 @@ namespace NomisCZ\SteamAuth\Providers;
 
 use Illuminate\Support\Fluent;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Zend\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Response\RedirectResponse;
 
 /**
  * Class SteamAuth


### PR DESCRIPTION
This may address error in https://github.com/NomisCZ/flarum-ext-auth-steam/blob/eefa087a8da8fd219437df2c9c952892be010dd6/src/Providers/SteamAuth.php#L251
```log
[2023-06-29 16:25:52] flarum.ERROR: Error: Class "Zend\Diactoros\Uri" not found in /vendor/nomiscz/flarum-ext-auth-steam/src/Providers/SteamAuth.php:251
Stack trace:
#0 /vendor/nomiscz/flarum-ext-auth-steam/src/Providers/SteamAuth.php(120): NomisCZ\SteamAuth\Providers\SteamAuth->buildUrl()
#1 /vendor/nomiscz/flarum-ext-auth-steam/src/Http/Controllers/SteamAuthController.php(40): NomisCZ\SteamAuth\Providers\SteamAuth->setRequest()
```
since https://discuss.flarum.org/d/22452-package-zendframework-zend-stratigility-is-abandoned/2